### PR TITLE
feat(openclaw-skill): improve agent patterns for initialization, planning, and streaming

### DIFF
--- a/openclaw-skill/references/initialization.md
+++ b/openclaw-skill/references/initialization.md
@@ -1,0 +1,258 @@
+# Initialization (Manual Setup)
+
+How to set up iloom for a project without using the interactive `il init` wizard.
+
+## When to Use This
+
+Use manual initialization instead of `il init` when:
+- You are an AI agent and cannot reliably drive the interactive wizard
+- You want deterministic, reproducible setup
+- You need to initialize many projects quickly
+
+## Prerequisites
+
+1. The project must be a **git repository** with at least one commit
+2. The project must have a **remote** configured (for GitHub issue tracking)
+3. iloom CLI must be installed (`il --version` to verify)
+
+## Step-by-Step Setup
+
+### 1. Create the `.iloom` directory
+
+```bash
+mkdir -p <project-root>/.iloom
+```
+
+### 2. Create `.iloom/settings.json` (project settings — committed to git)
+
+This file contains shared project configuration. At minimum:
+
+```json
+{
+  "mainBranch": "main"
+}
+```
+
+A typical project setup:
+
+```json
+{
+  "mainBranch": "main",
+  "colors": {
+    "terminal": true,
+    "vscode": true
+  },
+  "mergeBehavior": {
+    "mode": "github-draft-pr"
+  }
+}
+```
+
+### 3. Create `.iloom/settings.local.json` (personal settings — gitignored)
+
+This file contains per-developer preferences that should NOT be committed:
+
+```json
+{
+  "workflows": {
+    "issue": {
+      "permissionMode": "acceptEdits"
+    }
+  }
+}
+```
+
+### 4. Update `.gitignore`
+
+Ensure local/personal files are not tracked:
+
+```bash
+# Add to .gitignore
+echo '.iloom/settings.local.json' >> .gitignore
+echo '.vscode/settings.json' >> .gitignore   # Only if colors.vscode is true
+```
+
+### 5. Validate the configuration
+
+Run any iloom command to verify settings are loaded:
+
+```bash
+il list --json
+```
+
+If settings are valid, this returns a JSON array of looms. If there are errors, iloom will report them.
+
+### 6. (Optional) Validate against JSON Schema
+
+The settings JSON schema is bundled at `<iloom-install-path>/dist/schema/settings.schema.json`. You can validate your settings programmatically:
+
+```bash
+# Using ajv-cli (npm install -g ajv-cli)
+ajv validate -s "$(dirname $(which il))/../dist/schema/settings.schema.json" -d .iloom/settings.json
+
+# Or using node inline
+node -e "
+const schema = require('$(dirname $(which il))/../dist/schema/settings.schema.json');
+const settings = require('./.iloom/settings.json');
+// Basic structural check — schema is JSON Schema Draft 7
+console.log('Settings loaded:', Object.keys(settings));
+"
+```
+
+## Settings Reference
+
+### Layering Order (highest to lowest priority)
+
+1. **Local** — `.iloom/settings.local.json` (gitignored, per-machine)
+2. **Project** — `.iloom/settings.json` (committed, shared with team)
+3. **Global** — `~/.config/iloom-ai/settings.json` (all projects on this machine)
+
+Local overrides project, project overrides global.
+
+### Complete Settings Schema
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `mainBranch` | string | auto-detected | Primary branch name (`main`, `master`, etc.) |
+| `sourceEnvOnStart` | boolean | `false` | Source dotenv-flow files when launching processes |
+| `worktreePrefix` | string | `<repo>-looms` | Prefix for worktree directories (empty string disables) |
+| `protectedBranches` | string[] | `[mainBranch, "main", "master", "develop"]` | Branches that cannot be deleted |
+| `copyGitIgnoredPatterns` | string[] | `[]` | Glob patterns for gitignored files to copy to looms |
+
+#### `workflows` — Per-workflow-type settings
+
+Each workflow type (`issue`, `pr`, `regular`) supports:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `permissionMode` | enum | `"default"` | `"plan"` \| `"acceptEdits"` \| `"bypassPermissions"` \| `"default"` |
+| `noVerify` | boolean | `false` | Skip pre-commit hooks during commit/finish |
+| `startIde` | boolean | `true` | Open IDE when starting a loom |
+| `startDevServer` | boolean | `true` | Launch dev server on start |
+| `startAiAgent` | boolean | `true` | Launch Claude Code on start |
+| `startTerminal` | boolean | `false` | Open terminal window on start |
+| `generateSummary` | boolean | `true` | Generate session summary on finish |
+
+#### `agents` — Per-agent configuration
+
+Available agents: `iloom-issue-analyzer`, `iloom-issue-planner`, `iloom-issue-analyze-and-plan`, `iloom-issue-complexity-evaluator`, `iloom-issue-enhancer`, `iloom-issue-implementer`, `iloom-code-reviewer`, `iloom-artifact-reviewer`
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `model` | enum | — | `"sonnet"` \| `"opus"` \| `"haiku"` |
+| `enabled` | boolean | `true` | Whether this agent is enabled |
+| `review` | boolean | `false` | Review artifacts before posting |
+| `providers` | object | — | Map of `claude`/`gemini`/`codex` to model name strings |
+
+#### `plan` — Planning command settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `model` | enum | `"opus"` | Claude model for planning |
+| `planner` | enum | `"claude"` | AI provider: `"claude"` \| `"gemini"` \| `"codex"` |
+| `reviewer` | enum | `"none"` | Review provider: `"claude"` \| `"gemini"` \| `"codex"` \| `"none"` |
+
+#### `spin` — Spin orchestrator settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `model` | enum | `"opus"` | Claude model for spin |
+
+#### `summary` — Session summary settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `model` | enum | `"sonnet"` | Claude model for summaries |
+
+#### `issueManagement` — Issue tracker configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `provider` | enum | `"github"` | `"github"` \| `"linear"` \| `"jira"` |
+| `github.remote` | string | — | Git remote name for GitHub operations |
+| `linear.teamId` | string | — | Linear team identifier (e.g., `"ENG"`) |
+| `linear.apiToken` | string | — | **Local only** — never commit |
+| `jira.host` | string | — | Jira instance URL |
+| `jira.username` | string | — | Jira username/email |
+| `jira.apiToken` | string | — | **Local only** — never commit |
+| `jira.projectKey` | string | — | Jira project key (e.g., `"PROJ"`) |
+
+#### `mergeBehavior` — How looms are merged
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `mode` | enum | `"local"` | `"local"` \| `"github-pr"` \| `"github-draft-pr"` |
+| `remote` | string | — | Git remote for PR creation |
+| `autoCommitPush` | boolean | `true` (draft PR) | Auto-commit and push after code review |
+
+#### `ide` — Editor configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `type` | enum | `"vscode"` | `"vscode"` \| `"cursor"` \| `"webstorm"` \| `"sublime"` \| `"intellij"` \| `"windsurf"` \| `"antigravity"` |
+
+#### `colors` — Visual identification
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `terminal` | boolean | `true` | Terminal background colors per branch (macOS only) |
+| `vscode` | boolean | `false` | VSCode title bar colors per branch |
+
+#### `attribution`
+
+| Value | Description |
+|-------|-------------|
+| `"off"` | Never show iloom attribution |
+| `"upstreamOnly"` | Only for external/open-source repos (default) |
+| `"on"` | Always show attribution |
+
+#### `git` — Git operation settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `commitTimeout` | number | `60000` | Timeout (ms) for git commit operations (1s–600s) |
+
+## Example: Full Configuration
+
+**`.iloom/settings.json`** (committed):
+```json
+{
+  "mainBranch": "main",
+  "mergeBehavior": {
+    "mode": "github-draft-pr"
+  },
+  "issueManagement": {
+    "provider": "github"
+  },
+  "colors": {
+    "terminal": true,
+    "vscode": true
+  },
+  "agents": {
+    "iloom-issue-implementer": { "model": "opus" },
+    "iloom-code-reviewer": {
+      "providers": { "gemini": "gemini-3-pro-preview" }
+    },
+    "iloom-artifact-reviewer": {
+      "enabled": true,
+      "providers": { "gemini": "gemini-3-pro-preview" }
+    }
+  },
+  "attribution": "on"
+}
+```
+
+**`.iloom/settings.local.json`** (gitignored):
+```json
+{
+  "workflows": {
+    "issue": {
+      "permissionMode": "bypassPermissions",
+      "noVerify": true,
+      "startIde": false,
+      "startAiAgent": true,
+      "startTerminal": false
+    }
+  }
+}
+```

--- a/openclaw-skill/references/non-interactive-patterns.md
+++ b/openclaw-skill/references/non-interactive-patterns.md
@@ -22,13 +22,19 @@ bash command:"il list --json"
 
 ### Background Commands (use `background:true`)
 
-These commands launch Claude Code and run for extended periods:
+These commands launch Claude Code and run for extended periods. **Always run in background** to avoid timeout kills:
 
 | Command | Recommended Invocation |
 |---------|----------------------|
 | `il start` | `bash pty:true background:true command:"il start 42 --yolo --no-code --json"` |
-| `il spin` | `bash pty:true background:true command:"il spin --yolo"` |
-| `il plan` | `bash pty:true background:true command:"il plan --yolo"` |
+| `il spin` | `bash pty:true background:true command:"il spin --yolo --print --json-stream"` |
+| `il plan` | `bash pty:true background:true command:"il plan --yolo --print --json-stream"` |
+
+**Why `--print --json-stream` for `plan` and `spin`?**
+- `--print` enables headless/non-interactive output mode
+- `--json-stream` streams JSONL incrementally so you can monitor progress via `process action:poll`
+- Without `--json-stream`, `--print` buffers ALL output until completion (no visibility into what Claude is doing)
+- These commands can easily run 3-10+ minutes with Opus analyzing a codebase — foreground timeouts will kill them
 
 ### Foreground Commands (no `background:true`)
 
@@ -54,7 +60,7 @@ These commands complete quickly and return structured output:
 
 | Command | Note |
 |---------|------|
-| `il init` | Interactive wizard, must run foreground |
+| `il init` | Interactive wizard, must run foreground. **Not recommended for AI agents** — use manual setup instead (see `{baseDir}/references/initialization.md`) |
 | `il rebase` | May need Claude for conflict resolution |
 | `il shell` | Opens interactive subshell |
 
@@ -133,12 +139,15 @@ bash pty:true command:"il finish --force --cleanup --no-browser --json"
 ### Headless Planning
 
 ```bash
-bash pty:true command:"il plan --yolo --print --output-format json"
+bash pty:true background:true command:"il plan --yolo --print --json-stream"
+# Monitor: process action:poll sessionId:XXX
+# Full log: process action:log sessionId:XXX
 ```
 
 - `--yolo`: autonomous mode
 - `--print`: headless output
-- `--output-format json`: structured JSON response
+- `--json-stream`: stream JSONL incrementally (visible via poll/log)
+- `background:true`: **required** — planning sessions can run 3-10+ minutes
 
 ### Non-Interactive Commit
 


### PR DESCRIPTION
## Changes

### New: `references/initialization.md`
Complete manual setup guide for AI agents that replaces the need for `il init`:
- Step-by-step instructions for creating settings files directly
- Full settings schema reference with all options, types, defaults, and descriptions
- Example configurations for project and local settings
- Optional JSON schema validation

### Updated: `SKILL.md`
- **Workflow guidance:** Added "Sizeable Changes" vs "Small Changes" workflow documentation
  - Sizeable: plan → user review → `il start --no-claude --no-dev-server --no-code` → `il spin --print --json-stream`
  - Small: inline `il start '<description>' --yolo --no-code --json`
- **Initialization:** Now recommends manual setup for AI agents, `il init` marked as human-only alternative
- **Streaming:** `plan` and `spin` examples use `--print --json-stream` with `background:true`
- Safety rule 6 updated to prefer manual initialization

### Updated: `references/non-interactive-patterns.md`
- Background commands table updated with `--print --json-stream` for `plan`/`spin`
- Added explanation of why streaming + background matters (timeout avoidance, progress visibility)
- Headless Planning example updated to use background mode
- `il init` marked as not recommended for AI agents

## Context
These changes come from real experience using iloom from an OpenClaw AI agent:
- `il init` timed out twice due to nested Claude Code permission prompts
- `il plan --print --output-format json` buffered all output with zero visibility
- Foreground timeouts killed planning sessions that needed 3-5 minutes