### PR TITLE
docs: add safety rules — never kill foreign sessions, send progress updates

### DIFF
--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -130,3 +130,5 @@ bash pty:true background:true command:"il plan --yolo --print --json-stream"
 5. **Use `--json`** when you need to parse command output programmatically.
 6. **Prefer manual initialization** over `il init` — create `.iloom/settings.json` directly. See `{baseDir}/references/initialization.md`.
 7. **Respect worktree isolation** — each loom is an independent workspace. Run commands from within the correct worktree directory.
+8. **NEVER kill a background session you did not start.** Other looms may be running from separate planning or development sessions (the user's own work, other agents, or prior conversations). When you see unfamiliar background sessions, **leave them alone**. Only kill sessions you explicitly launched in the current workflow. If unsure, ask the user.
+9. **Send progress updates mid-turn.** Long-running loom operations (plan, spin, commit, finish) can take minutes. Use the `message` tool to send incremental status updates to the user while waiting — don't go silent. Examples: "🧵 Spin started for issue #5, monitoring…", "✅ Tests passing, spin entering code review phase", "🔀 Merging to main…". Keep the user in the loop.

--- a/openclaw-skill/references/non-interactive-patterns.md
+++ b/openclaw-skill/references/non-interactive-patterns.md
@@ -85,9 +85,13 @@ process action:submit sessionId:XXX data:"yes"
 # 5. Send raw data without newline
 process action:write sessionId:XXX data:"y"
 
-# 6. Terminate if needed
+# 6. Terminate if needed (YOUR sessions only — see warning below)
 process action:kill sessionId:XXX
 ```
+
+> ⚠️ **CRITICAL: Never kill a session you did not start.**
+>
+> When listing background processes, you may see sessions from other workflows — the user's own planning sessions, other agents, or prior conversations. These are **not yours to manage**. Only kill sessions you explicitly launched in the current workflow. If you're unsure whether a session is yours, **ask the user** before terminating it. Killing someone else's long-running `plan` or `spin` session destroys work in progress that cannot be recovered.
 
 ---
 


### PR DESCRIPTION
## Changes

Builds on top of PR #3 (agent-patterns branch). Adds 1 commit.

**SKILL.md — two new safety rules:**
- **Rule #8:** Never kill a background session you did not start
- **Rule #9:** Send progress updates mid-turn during long loom ops

**non-interactive-patterns.md:**
- Critical warning next to `process action:kill` about not killing foreign sessions

## Context

An agent killed a running `il plan` session from a separate workflow, destroying work in progress.