### PR TITLE
docs: guide LLM to ask user about GitHub remote config

### DIFF
--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -43,6 +43,41 @@ bash pty:true command:"il init"
 
 `il init` launches an interactive Claude-guided configuration wizard. It requires foreground PTY and is designed for human interaction — **not recommended for AI agents** due to nested interactive prompts and timeout sensitivity.
 
+## GitHub Remote Configuration (Fork Workflows)
+
+When a project has **multiple git remotes** (e.g., `origin` + `fork`, or `upstream` + `origin`), iloom needs to know which remote to use for issue management and which to push to.
+
+**Do NOT auto-configure `issueManagement.github.remote`.** Instead, **ask the user** which remote to target. The correct choice depends on:
+
+- Whether the user has write access to the upstream repo
+- Whether issues live on the upstream or the fork
+- Whether PRs should target the upstream or the fork
+
+**Use `.iloom/settings.local.json`** (not the shared `settings.json`) for per-developer remote configuration, since this is a personal preference that shouldn't be committed:
+
+```json
+{
+  "issueManagement": {
+    "github": {
+      "remote": "upstream"
+    }
+  },
+  "mergeBehavior": {
+    "remote": "origin"
+  }
+}
+```
+
+**Standard remote naming convention:**
+- `origin` = your fork (where you have push access)
+- `upstream` = the original repo (where issues live)
+
+iloom assumes `origin` is yours by default. If remotes are named differently, configure `issueManagement.github.remote` and `mergeBehavior.remote` explicitly.
+
+Common patterns:
+- **Fork workflow:** Issues on `upstream`, push/PR from `origin` (your fork)
+- **Direct access (no fork):** Both issues and push on `origin` — no extra config needed
+
 ## Workflow: Choosing the Right Approach
 
 ### Sizeable Changes (multiple issues, architectural work)
@@ -59,7 +94,7 @@ For anything non-trivial, use the **plan → review → start → spin** workflo
 
 3. **Start:** Create the workspace without launching Claude or dev server
    ```bash
-   bash pty:true command:"il start <issue#> --yolo --no-code --no-dev-server --no-claude --json"
+   bash pty:true command:"il start <issue#> --yolo --no-code --no-dev-server --no-claude --no-terminal --json"
    ```
 
 4. **Spin:** Launch Claude separately with streaming output

--- a/openclaw-skill/references/initialization.md
+++ b/openclaw-skill/references/initialization.md
@@ -62,7 +62,30 @@ This file contains per-developer preferences that should NOT be committed:
 }
 ```
 
-### 4. Update `.gitignore`
+### 4. Configure GitHub Remote (Fork Workflows)
+
+If the project has **multiple git remotes** (e.g., a fork workflow), configure which remote iloom uses for issue tracking vs. pushing. **Do not guess — ask the user.**
+
+Add to `.iloom/settings.local.json` (not `settings.json`, since this is per-developer):
+
+```json
+{
+  "issueManagement": {
+    "github": {
+      "remote": "upstream"
+    }
+  },
+  "mergeBehavior": {
+    "remote": "origin"
+  }
+}
+```
+
+**Standard convention:** `origin` = your fork, `upstream` = the original repo. iloom assumes `origin` is yours by default.
+
+`issueManagement.github.remote` controls where issues are read/created. `mergeBehavior.remote` controls where branches are pushed and PRs are created. In fork workflows, issues live on `upstream` while you push to `origin`.
+
+### 5. Update `.gitignore`
 
 Ensure local/personal files are not tracked:
 
@@ -72,7 +95,7 @@ echo '.iloom/settings.local.json' >> .gitignore
 echo '.vscode/settings.json' >> .gitignore   # Only if colors.vscode is true
 ```
 
-### 5. Validate the configuration
+### 6. Validate the configuration
 
 Run any iloom command to verify settings are loaded:
 
@@ -82,7 +105,7 @@ il list --json
 
 If settings are valid, this returns a JSON array of looms. If there are errors, iloom will report them.
 
-### 6. (Optional) Validate against JSON Schema
+### 7. (Optional) Validate against JSON Schema
 
 The settings JSON schema is bundled at `<iloom-install-path>/dist/schema/settings.schema.json`. You can validate your settings programmatically:
 

--- a/openclaw-skill/references/non-interactive-patterns.md
+++ b/openclaw-skill/references/non-interactive-patterns.md
@@ -26,7 +26,7 @@ These commands launch Claude Code and run for extended periods. **Always run in 
 
 | Command | Recommended Invocation |
 |---------|----------------------|
-| `il start` | `bash pty:true background:true command:"il start 42 --yolo --no-code --json"` |
+| `il start` | `bash pty:true background:true command:"il start 42 --yolo --no-code --no-terminal --json"` |
 | `il spin` | `bash pty:true background:true command:"il spin --yolo --print --json-stream"` |
 | `il plan` | `bash pty:true background:true command:"il plan --yolo --print --json-stream"` |
 
@@ -104,6 +104,7 @@ Every interactive prompt in iloom and the flag(s) that bypass it:
 | `start` | "Enter issue number..." | Provide `[identifier]` argument |
 | `start` | "Create as a child loom?" | `--child-loom` or `--no-child-loom` |
 | `start` | "bypassPermissions warning" | Already implied by `--yolo`; or `--no-claude` |
+| `start` | Opens terminal window | `--no-terminal` |
 | `finish` | "Clean up worktree?" | `--cleanup` or `--no-cleanup` |
 | `finish` | Commit message review | `--force` |
 | `finish` | General confirmations | `--force` |
@@ -122,11 +123,12 @@ Every interactive prompt in iloom and the flag(s) that bypass it:
 ### Full Autonomous Start (create workspace)
 
 ```bash
-bash pty:true background:true command:"il start <issue> --yolo --no-code --json"
+bash pty:true background:true command:"il start <issue> --yolo --no-code --no-terminal --json"
 ```
 
 - `--yolo`: bypass all permission prompts
 - `--no-code`: don't open VS Code
+- `--no-terminal`: don't open a terminal window
 - `--json`: structured output
 
 ### Full Autonomous Finish (merge and cleanup)


### PR DESCRIPTION
- Add 'GitHub Remote Configuration' section to SKILL.md explaining fork workflows and why agents should ask users instead of auto-configuring
- Document standard remote naming convention (origin = your fork, upstream = original repo)  
- Document settings.local.json for per-developer remote preferences
- Add --no-terminal to all autonomous start patterns
- Add fork workflow setup step to initialization.md

Closes #7