### PR TITLE
docs: document standard remote naming convention and troubleshooting

### DIFF
--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -20,6 +20,55 @@ bash pty:true command:"il list --json"
 bash command:"il list --json"
 ```
 
+## Repository Setup (Forking & Remotes)
+
+When working on a forked repository, **always use standard remote naming**:
+
+- **`origin`** = your fork (you have push access)
+- **`upstream`** = the original repo (read-only for contributors)
+
+iloom defaults to `origin` for push operations (draft PRs, branch pushing). If `origin` points to a repo you can't write to, pushes will fail.
+
+### Setting up a fork correctly
+
+```bash
+# Clone your fork (this sets origin = your fork automatically)
+gh repo fork <owner>/<repo> --clone
+
+# Or manually:
+git clone git@github.com:<you>/<repo>.git
+cd <repo>
+git remote add upstream git@github.com:<owner>/<repo>.git
+```
+
+### If remotes are already misconfigured
+
+```bash
+# Check current remotes
+git remote -v
+
+# Rename to follow convention
+git remote rename origin upstream
+git remote rename fork origin
+```
+
+### Configuring iloom for fork workflows
+
+If issues live on the upstream repo but you push to your fork, add to `.iloom/settings.local.json`:
+
+```json
+{
+  "issueManagement": {
+    "github": { "remote": "upstream" }
+  },
+  "mergeBehavior": {
+    "remote": "origin"
+  }
+}
+```
+
+> **⚠️ Do not auto-configure remotes.** If multiple remotes are detected, ask the user which remote to use for issues and which for pushing. Use `.iloom/settings.local.json` (not the shared `settings.json`) since this is a per-developer preference.
+
 ## Project Initialization (First-Time Setup)
 
 Before using any iloom commands, the project must be initialized:
@@ -101,3 +150,22 @@ bash pty:true command:"il plan --yolo --print --output-format json"
 5. **Use `--json`** when you need to parse command output programmatically.
 6. **Do not run `il init` in background mode** — it requires foreground interactive setup.
 7. **Respect worktree isolation** — each loom is an independent workspace. Run commands from within the correct worktree directory.
+
+## Troubleshooting
+
+### "Permission denied" when pushing draft PRs
+
+```
+ERROR: Permission to <owner>/<repo>.git denied to <you>.
+```
+
+**Cause:** `origin` points to the upstream repo instead of your fork. iloom pushes to `origin` by default.
+
+**Fix:** Rename remotes to follow convention (`origin` = your fork, `upstream` = original repo):
+
+```bash
+git remote rename origin upstream
+git remote rename fork origin   # or whatever your fork remote is named
+```
+
+Then update `.iloom/settings.local.json` if needed (see "Repository Setup" section above).


### PR DESCRIPTION
- Add 'Repository Setup' section to SKILL.md with fork workflow guidance
- Document standard naming: origin = your fork, upstream = original repo
- Include `gh repo fork` and manual setup instructions  
- Add troubleshooting section for 'Permission denied' push errors
- Clarify iloom defaults to origin for push operations

Closes #10