### PR TITLE
docs: clarify remote semantics, label requirements, and plan prompt

### DIFF
--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -45,13 +45,15 @@ bash pty:true command:"il init"
 
 ## GitHub Remote Configuration (Fork Workflows)
 
-When a project has **multiple git remotes** (e.g., `origin` + `fork`, or `upstream` + `origin`), iloom needs to know which remote to use for issue management and which to push to.
+When a project has **multiple git remotes** (e.g., `origin` + `upstream`), iloom needs to know which remote to use for different operations.
 
-**Do NOT auto-configure `issueManagement.github.remote`.** Instead, **ask the user** which remote to target. The correct choice depends on:
+**Do NOT auto-configure remotes.** Instead, **ask the user** which remote to target. The correct choice depends on their workflow and permissions.
 
-- Whether the user has write access to the upstream repo
-- Whether issues live on the upstream or the fork
-- Whether PRs should target the upstream or the fork
+### Understanding the Two Remote Settings
+
+- **`issueManagement.github.remote`** — The **canonical GitHub repository** for all GitHub operations: listing/creating issues, opening PRs, commenting, closing issues. In a fork workflow, this is typically `upstream` because issues and PRs live on the original repo.
+
+- **`mergeBehavior.remote`** — The remote iloom **pushes branches to**. In a fork workflow, this is typically `origin` (your fork), because you have push access there. iloom pushes your branch here, then opens a cross-fork PR on the `issueManagement` repo.
 
 **Use `.iloom/settings.local.json`** (not the shared `settings.json`) for per-developer remote configuration, since this is a personal preference that shouldn't be committed:
 
@@ -70,13 +72,17 @@ When a project has **multiple git remotes** (e.g., `origin` + `fork`, or `upstre
 
 **Standard remote naming convention:**
 - `origin` = your fork (where you have push access)
-- `upstream` = the original repo (where issues live)
+- `upstream` = the original repo (where issues and PRs live)
 
-iloom assumes `origin` is yours by default. If remotes are named differently, configure `issueManagement.github.remote` and `mergeBehavior.remote` explicitly.
+iloom assumes `origin` is yours by default. If remotes are named differently, configure both settings explicitly.
 
-Common patterns:
-- **Fork workflow:** Issues on `upstream`, push/PR from `origin` (your fork)
-- **Direct access (no fork):** Both issues and push on `origin` — no extra config needed
+### Common Patterns
+
+| Workflow | `issueManagement.github.remote` | `mergeBehavior.remote` | Notes |
+|----------|--------------------------------|----------------------|-------|
+| **Fork workflow** | `upstream` | `origin` | Issues/PRs on upstream, push to your fork |
+| **Direct access** | `origin` | `origin` | No fork — no extra config needed |
+| **Fork with local issues** | `origin` | `origin` | Issues on your fork (e.g., fork has issues enabled) |
 
 ## Workflow: Choosing the Right Approach
 
@@ -84,9 +90,9 @@ Common patterns:
 
 For anything non-trivial, use the **plan → review → start → spin** workflow:
 
-1. **Plan:** Decompose the work into issues
+1. **Plan:** Decompose the work into issues (prompt is required with `--yolo`)
    ```bash
-   bash pty:true background:true command:"il plan --yolo --print --json-stream"
+   bash pty:true background:true command:"il plan --yolo --print --json-stream 'Description of work to plan'"
    # Monitor: process action:poll sessionId:XXX
    ```
 
@@ -140,12 +146,14 @@ bash pty:true background:true command:"il commit --no-review --json-stream"
 When the user has an idea for an improvement, new feature, or wants to decompose work into issues, use `il plan`:
 
 ```bash
-bash pty:true background:true command:"il plan --yolo --print --json-stream"
+bash pty:true background:true command:"il plan --yolo --print --json-stream 'Describe the feature or work to plan'"
 # Monitor: process action:poll sessionId:XXX
 # Full log: process action:log sessionId:XXX
 ```
 
 `il plan` launches an autonomous AI planning session that reads the codebase and creates structured issues with dependencies. Always prefer this over manually creating issues.
+
+**Important:** `--yolo` mode requires a **prompt argument** (a description string) or an **issue identifier** (e.g., `il plan --yolo 42`). Without one, the command will fail immediately.
 
 **Important:** Commands that can run for extended periods — `plan`, `spin`, `commit`, `finish`, and `rebase` — should be run in **background mode** (`background:true`) with `--json-stream` (and `--print` for plan/spin). The `--json-stream` flag streams JSONL incrementally so you can monitor progress via `process action:poll`. Without it, you get zero visibility until the command completes.
 
@@ -164,8 +172,9 @@ bash pty:true background:true command:"il plan --yolo --print --json-stream"
 2. **Use `background:true`** for commands that launch Claude or run extended operations: `start`, `spin`, `plan`, `commit`, `finish`, `rebase`.
 3. **Never run `il finish` without `--force`** in autonomous mode — it will hang on confirmation prompts.
 4. **Always pass explicit flags** to avoid interactive prompts. See `{baseDir}/references/non-interactive-patterns.md` for the complete decision bypass map.
-5. **Use `--json`** when you need to parse command output programmatically.
+5. **Use `--json`** when you need to parse command output programmatically. **`--json` and `--json-stream` are mutually exclusive** — prefer `--json-stream` for commands that support it (commit, finish, rebase) since it provides incremental visibility. Use `--json` only for commands without `--json-stream` support (list, cleanup, start, etc.).
 6. **Prefer manual initialization** over `il init` — create `.iloom/settings.json` directly. See `{baseDir}/references/initialization.md`.
 7. **Respect worktree isolation** — each loom is an independent workspace. Run commands from within the correct worktree directory.
 8. **NEVER kill a background session you did not start.** Other looms may be running from separate planning or development sessions (the user's own work, other agents, or prior conversations). When you see unfamiliar background sessions, **leave them alone**. Only kill sessions you explicitly launched in the current workflow. If unsure, ask the user.
 9. **Send progress updates mid-turn.** Long-running loom operations (plan, spin, commit, finish) can take minutes. Use the `message` tool to send incremental status updates to the user while waiting — don't go silent. Examples: "🧵 Spin started for issue #5, monitoring…", "✅ Tests passing, spin entering code review phase", "🔀 Merging to main…". Keep the user in the loop.
+10. **GitHub labels must already exist on the repo.** `gh issue create --label` will fail if the label doesn't exist. If the user has **write or triage permissions** on the `issueManagement.github.remote` repo, you can create labels first (`gh label create <name> -R <repo>`). Otherwise, list existing labels (`gh label list -R <repo>`) and only use those, or omit labels entirely if none match.

--- a/openclaw-skill/references/initialization.md
+++ b/openclaw-skill/references/initialization.md
@@ -83,7 +83,11 @@ Add to `.iloom/settings.local.json` (not `settings.json`, since this is per-deve
 
 **Standard convention:** `origin` = your fork, `upstream` = the original repo. iloom assumes `origin` is yours by default.
 
-`issueManagement.github.remote` controls where issues are read/created. `mergeBehavior.remote` controls where branches are pushed and PRs are created. In fork workflows, issues live on `upstream` while you push to `origin`.
+**Understanding the two settings:**
+- **`issueManagement.github.remote`** — The canonical GitHub repository for all GitHub operations: listing/creating issues, **opening PRs**, commenting, closing issues. PRs are opened against this repo.
+- **`mergeBehavior.remote`** — The remote iloom pushes branches to. In a fork workflow, branches are pushed here, then a cross-fork PR is opened on the `issueManagement` repo.
+
+In fork workflows, issues and PRs live on `upstream` while you push branches to `origin`.
 
 ### 5. Update `.gitignore`
 

--- a/openclaw-skill/references/non-interactive-patterns.md
+++ b/openclaw-skill/references/non-interactive-patterns.md
@@ -160,12 +160,12 @@ bash pty:true background:true command:"il finish --force --cleanup --no-browser 
 ### Headless Planning
 
 ```bash
-bash pty:true background:true command:"il plan --yolo --print --json-stream"
+bash pty:true background:true command:"il plan --yolo --print --json-stream 'Description of work to plan'"
 # Monitor: process action:poll sessionId:XXX
 # Full log: process action:log sessionId:XXX
 ```
 
-- `--yolo`: autonomous mode
+- `--yolo`: autonomous mode (**requires a prompt argument or issue identifier**)
 - `--print`: headless output
 - `--json-stream`: stream JSONL incrementally (visible via poll/log)
 - `background:true`: **required** — planning sessions can run 3-10+ minutes

--- a/openclaw-skill/references/planning-and-issues.md
+++ b/openclaw-skill/references/planning-and-issues.md
@@ -23,14 +23,16 @@ Launch an interactive AI planning session to decompose features into child issue
 
 ### Modes
 
-**Fresh Planning Mode** — no identifier provided:
+**Fresh Planning Mode** — prompt describes the work to plan:
 ```bash
-# Interactive planning session (background, autonomous)
-bash pty:true background:true command:"il plan --yolo"
+# Autonomous planning with prompt (required for --yolo)
+bash pty:true background:true command:"il plan --yolo --print --json-stream 'Add authentication to the API'"
 
 # Headless planning with JSON output
-bash pty:true command:"il plan --yolo --print --output-format json"
+bash pty:true command:"il plan --yolo --print --output-format json 'Add authentication to the API'"
 ```
+
+> **Note:** `--yolo` mode requires either a **prompt argument** (description string) or an **issue identifier**. Without one, the command fails immediately.
 
 **Issue Decomposition Mode** — issue identifier provided:
 ```bash
@@ -46,7 +48,7 @@ bash pty:true background:true command:"il plan 'ENG-456' --yolo"
 This command **launches Claude**. Use `background:true` for interactive sessions:
 
 ```bash
-bash pty:true background:true command:"il plan --yolo"
+bash pty:true background:true command:"il plan --yolo --print --json-stream 'Description of work'"
 
 # Monitor the planning session
 process action:log sessionId:XXX


### PR DESCRIPTION
## Summary

Three documentation improvements based on real-world usage learnings:

### 1. Remote Configuration Semantics (corrected)

Clarified the distinct roles of the two remote settings:
- **`issueManagement.github.remote`** — The canonical GitHub repo for *all* GitHub operations: issues, PRs, comments, closing. PRs are opened against this repo.
- **`mergeBehavior.remote`** — Where branches are pushed. In fork workflows, branches go here and cross-fork PRs target the issueManagement repo.

Added a table showing common workflow patterns (fork, direct access, fork with local issues).

Updated in: SKILL.md, initialization.md

### 2. GitHub Label Requirements

Labels passed to `gh issue create --label` must already exist on the repo. Added safety rule #10 with guidance:
- If user has write/triage permissions → create labels first (`gh label create`)
- Otherwise → list existing labels and use only those, or omit labels entirely

Updated in: SKILL.md

### 3. `il plan --yolo` Requires a Prompt

`--yolo` mode requires either a prompt argument or issue identifier. Without one, the command fails immediately. Updated all plan examples to include a prompt string and added explicit notes about the requirement.

Also documented `--json` / `--json-stream` mutual exclusivity in safety rule #5.

Updated in: SKILL.md, planning-and-issues.md, non-interactive-patterns.md