### PR TITLE
Refactor merge mode from provider-specific to generic (pr, draft-pr)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Control how `il finish` handles your work. Configure in `.iloom/settings.json`:
 ```json
 {
   "mergeBehavior": {
-    "mode": "local"  // "local", "github-pr", or "github-draft-pr"
+    "mode": "local"  // "local", "pr", or "draft-pr"
   }
 }
 ```
@@ -352,8 +352,8 @@ Control how `il finish` handles your work. Configure in `.iloom/settings.json`:
 | **Mode** | **Description** |
 |----------|-----------------|
 | `local` | (Default) Merge directly into main branch locally. Fast-forward merge, no PR created. |
-| `github-pr` | Push branch and create a GitHub PR on `il finish`. Worktree cleanup is optional. |
-| `github-draft-pr` | Create a draft PR immediately on `il start`. On `il finish`, the PR is marked ready for review. **Recommended for contributions to forked repos.** |
+| `pr` | Push branch and create a PR on `il finish`. Worktree cleanup is optional. |
+| `draft-pr` | Create a draft PR immediately on `il start`. On `il finish`, the PR is marked ready for review. **Recommended for contributions to forked repos.** |
 
 ### Artifact Review
 
@@ -411,7 +411,7 @@ When `il finish` or `il rebase` encounter rebase conflicts, iloom automatically 
 
 Note: Potentially destructive commands like `git reset` and `git checkout` are intentionally not auto-approved to prevent accidental data loss.
 
-**When to use `github-draft-pr`:**
+**When to use `draft-pr`:**
 - **Contributing to forks:** When you don't are contributing to a forked repo use this mode to create the PR from your fork immediately, allowing iloom's agents to post workflow comments directly to the PR instead of writing to the upstream repo's issues (which may not be appreciated by the repo owners).
 - CI runs on your branch during development (draft PRs trigger CI on most repos)
 - Your team requires PRs for all changes (no direct merges to main)
@@ -834,7 +834,7 @@ This command:
 1. Forks the repository (if not already forked)
 2. Clones your fork locally
 3. Configures iloom for the project
-4. Sets merge behavior to `github-draft-pr` (creates a draft PR immediately when you start work)
+4. Sets merge behavior to `draft-pr` (creates a draft PR immediately when you start work)
 
 The draft PR workflow is ideal for open source: as you work, iloom posts the AI's analysis, implementation plan, and progress directly to that draft PR—giving maintainers full context before the code is even ready for review.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -128,12 +128,12 @@ iloom supports three modes for handling finished work:
 | Mode | When PR is Created | Best For |
 |------|-------------------|----------|
 | `local` | Never | Solo development, rapid iteration |
-| `github-pr` | On `il finish` | Team environments |
-| `github-draft-pr` | On `il start` | Open source, early visibility |
+| `pr` | On `il finish` | Team environments |
+| `draft-pr` | On `il start` | Open source, early visibility |
 
 - **Local** (default): Merge directly to main without creating a PR
-- **GitHub PR**: Create a PR when you run `il finish`
-- **GitHub Draft PR**: Create a draft PR on `il start`, mark it ready on `il finish`
+- **PR**: Create a PR when you run `il finish`
+- **Draft PR**: Create a draft PR on `il start`, mark it ready on `il finish`
 
 Configure with:
 
@@ -452,7 +452,7 @@ il config "use upstream remote for issues"
 
 **Key features with GitHub:**
 - Issue and PR support
-- All workflow modes available (local, github-pr, github-draft-pr)
+- All workflow modes available (local, pr, draft-pr)
 - Issue references: `#123`, PR references: `#456`
 
 ### Linear Setup

--- a/docs/iloom-commands.md
+++ b/docs/iloom-commands.md
@@ -288,9 +288,9 @@ il finish [options]
 | `-n`, `--dry-run` | Preview actions without executing |
 | `--pr` | Treat input as PR number |
 | `--skip-build` | Skip post-merge build verification |
-| `--no-browser` | Skip opening PR in browser (github-pr and github-draft-pr modes) |
+| `--no-browser` | Skip opening PR in browser (pr and draft-pr modes) |
 | `--cleanup` | Clean up worktree after finishing (default in local mode) |
-| `--no-cleanup` | Keep worktree after finishing (default in github-pr and github-draft-pr modes)|
+| `--no-cleanup` | Keep worktree after finishing (default in pr and draft-pr modes)|
 | `--review` | Review commit message before committing (default: auto-commit without review) |
 
 **Merge Behavior Modes:**
@@ -308,14 +308,14 @@ Behavior depends on the `mergeBehavior.mode` setting in your iloom configuration
 8. Runs post-merge build verification
 9. Cleans up worktree and database branch
 
-**`github-pr`:**
+**`pr`:**
 1. Same validation pipeline as local mode
 2. Pushes branch to remote
 3. Creates GitHub pull request
 4. Opens PR in browser (unless `--no-browser` or `openBrowserOnFinish: false`)
 5. Prompts for cleanup (or use `--cleanup`/`--no-cleanup` flags)
 
-**`github-draft-pr`:**
+**`draft-pr`:**
 1. Same validation pipeline as local mode
 2. Removes placeholder commit and pushes final commits
 3. Marks draft PR as ready for review
@@ -350,12 +350,12 @@ For Payload CMS projects, iloom automatically detects and handles migration conf
 
 **Browser Opening Configuration:**
 
-By default, `il finish` opens the PR in your browser after creation (github-pr mode) or marking ready (github-draft-pr mode). To disable this permanently, set `openBrowserOnFinish` to `false` in your settings:
+By default, `il finish` opens the PR in your browser after creation (pr mode) or marking ready (draft-pr mode). To disable this permanently, set `openBrowserOnFinish` to `false` in your settings:
 
 ```json
 {
   "mergeBehavior": {
-    "mode": "github-pr",
+    "mode": "pr",
     "openBrowserOnFinish": false
   }
 }
@@ -2033,7 +2033,7 @@ il init
 
 # Natural language configuration
 il init "set my IDE to windsurf and help me configure linear"
-il init "switch to github-pr merge mode"
+il init "switch to pr merge mode"
 il init "configure neon database with project ID abc-123"
 ```
 
@@ -2041,7 +2041,7 @@ il init "configure neon database with project ID abc-123"
 - Issue tracker (GitHub/Linear/Jira)
 - Database provider (Neon)
 - IDE preference (VS Code, Cursor, Windsurf, etc.)
-- Merge behavior (local vs github-pr)
+- Merge behavior (local, pr, draft-pr)
 - Permission modes
 - Project type (web app, CLI tool, etc.)
 - Base port for development servers
@@ -2176,7 +2176,7 @@ il contribute [repository]
 3. Sets up upstream remote to track the original repository
 4. Configures iloom settings:
    - Sets `issueManagement.github.remote` to `upstream`
-   - Sets `mergeBehavior.mode` to `github-draft-pr`
+   - Sets `mergeBehavior.mode` to `draft-pr`
 
 **Examples:**
 
@@ -2193,7 +2193,7 @@ il contribute "facebook/react"
 **Notes:**
 - Requires GitHub CLI (`gh`) to be authenticated
 - Creates fork if it doesn't exist
-- Sets up `github-draft-pr` mode so PRs are created immediately when you start work
+- Sets up `draft-pr` mode so PRs are created immediately when you start work
 - Draft PRs receive iloom's AI analysis and planning comments, giving maintainers full context
 - For iloom contributions, see [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidelines
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -79,12 +79,12 @@ describe('GitHub CLI validation', () => {
         expect(mockExit).toHaveBeenCalledWith(1)
       })
 
-      it('should exit when gh CLI missing and merge mode is github-pr', async () => {
+      it('should exit when gh CLI missing and merge mode is pr', async () => {
         commandName = 'finish'
         mockIsCliAvailable.mockReturnValue(false)
         mockLoadSettings.mockResolvedValue({
           issueManagement: { provider: 'linear' },
-          mergeBehavior: { mode: 'github-pr' },
+          mergeBehavior: { mode: 'pr' },
         })
 
         await validateGhCliForCommand(createMockCommand())
@@ -92,12 +92,12 @@ describe('GitHub CLI validation', () => {
         expect(mockExit).toHaveBeenCalledWith(1)
       })
 
-      it('should exit when gh CLI missing and merge mode is github-draft-pr', async () => {
+      it('should exit when gh CLI missing and merge mode is draft-pr', async () => {
         commandName = 'finish'
         mockIsCliAvailable.mockReturnValue(false)
         mockLoadSettings.mockResolvedValue({
           issueManagement: { provider: 'linear' },
-          mergeBehavior: { mode: 'github-draft-pr' },
+          mergeBehavior: { mode: 'draft-pr' },
         })
 
         await validateGhCliForCommand(createMockCommand())

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -218,7 +218,7 @@ export async function validateGhCliForCommand(command: Command): Promise<void> {
   // Commands that ALWAYS require gh CLI regardless of configuration
   const alwaysRequireGh = ['feedback', 'contribute']
 
-  // Commands that require gh CLI when GitHub provider or github-pr merge mode
+  // Commands that require gh CLI when GitHub provider or pr/draft-pr merge mode with GitHub VCS
   const conditionallyRequireGh = ['start', 'finish', 'enhance', 'add-issue', 'ignite', 'spin']
 
   // Commands that only warn if gh CLI is missing (secondary/utility commands)
@@ -244,7 +244,8 @@ export async function validateGhCliForCommand(command: Command): Promise<void> {
       const provider = IssueTrackerFactory.getProviderName(settings)
       const mergeBehaviorMode = settings.mergeBehavior?.mode
 
-      needsGhCli = provider === 'github' || mergeBehaviorMode === 'github-pr' || mergeBehaviorMode === 'github-draft-pr'
+      const isPrMode = (mergeBehaviorMode as string) === 'pr' || (mergeBehaviorMode as string) === 'draft-pr'
+      needsGhCli = provider === 'github' || isPrMode
     } catch {
       // If we can't load settings, assume we might need gh CLI
       needsGhCli = true
@@ -257,7 +258,7 @@ export async function validateGhCliForCommand(command: Command): Promise<void> {
       // ERROR: gh CLI is required for this command
       const errorMessage = alwaysRequireGh.includes(commandName)
         ? `The "${commandName}" command requires GitHub CLI (gh) to be installed.`
-        : `GitHub CLI (gh) is required when using GitHub as the issue tracker or "github-pr"/"github-draft-pr" merge mode.`
+        : `GitHub CLI (gh) is required when using GitHub as the issue tracker or "pr"/"draft-pr" merge mode with GitHub.`
 
       logger.error(errorMessage)
       logger.info('')
@@ -277,11 +278,12 @@ export async function validateGhCliForCommand(command: Command): Promise<void> {
 
         const provider = IssueTrackerFactory.getProviderName(settings)
         const mergeBehaviorMode = settings.mergeBehavior?.mode
+        const isPrMode = (mergeBehaviorMode as string) === 'pr' || (mergeBehaviorMode as string) === 'draft-pr'
 
-        if (provider === 'github' || mergeBehaviorMode === 'github-pr' || mergeBehaviorMode === 'github-draft-pr') {
+        if (provider === 'github' || isPrMode) {
           logger.warn('GitHub CLI (gh) is not installed.')
           logger.warn(
-            'Some features may not work correctly with your current configuration (GitHub provider or "github-pr"/"github-draft-pr" merge mode).'
+            'Some features may not work correctly with your current configuration (GitHub provider or PR merge mode).'
           )
           logger.info('To install: brew install gh (macOS) or see https://github.com/cli/cli#installation')
           logger.info('')
@@ -621,7 +623,7 @@ program
   .option('--pr <number>', 'Treat input as PR number', parseFloat)
   .option('--skip-build', 'Skip post-merge build verification')
   .option('--skip-to-pr', 'Skip rebase/validation/commit, go directly to PR creation (debug)')
-  .option('--no-browser', 'Skip opening PR in browser (github-pr and github-draft-pr modes)')
+  .option('--no-browser', 'Skip opening PR in browser (pr and draft-pr modes)')
   .option('--cleanup', 'Clean up worktree after finishing (default in local mode)')
   .option('--no-cleanup', 'Keep worktree after finishing')
   .option('--review', 'Review commit message before committing (default: auto-commit without review)')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { GitWorktreeManager } from './lib/GitWorktreeManager.js'
 import { ShellCompletion } from './lib/ShellCompletion.js'
 import { SettingsManager } from './lib/SettingsManager.js'
 import { IssueTrackerFactory } from './lib/IssueTrackerFactory.js'
+import { VCSProviderFactory } from './lib/VCSProviderFactory.js'
 import { IssueEnhancementService } from './lib/IssueEnhancementService.js'
 import { AgentManager } from './lib/AgentManager.js'
 import { GitHubService } from './lib/GitHubService.js'
@@ -245,7 +246,8 @@ export async function validateGhCliForCommand(command: Command): Promise<void> {
       const mergeBehaviorMode = settings.mergeBehavior?.mode
 
       const isPrMode = (mergeBehaviorMode as string) === 'pr' || (mergeBehaviorMode as string) === 'draft-pr'
-      needsGhCli = provider === 'github' || isPrMode
+      const vcsProvider = VCSProviderFactory.create(settings)
+      needsGhCli = provider === 'github' || (isPrMode && vcsProvider === null)
     } catch {
       // If we can't load settings, assume we might need gh CLI
       needsGhCli = true

--- a/src/commands/contribute.ts
+++ b/src/commands/contribute.ts
@@ -414,7 +414,7 @@ export class ContributeCommand {
 		// Create .iloom directory
 		await mkdir(iloomDir, { recursive: true })
 
-		// Create settings.json with upstream remote configuration and github-pr mode
+		// Create settings.json with upstream remote configuration and draft-pr mode
 		const settings = {
 			issueManagement: {
 				github: {
@@ -422,7 +422,7 @@ export class ContributeCommand {
 				},
 			},
 			mergeBehavior: {
-				mode: 'github-draft-pr',
+				mode: 'draft-pr',
 			},
 		}
 

--- a/src/commands/finish.pr-workflow.test.ts
+++ b/src/commands/finish.pr-workflow.test.ts
@@ -538,7 +538,7 @@ describe('FinishCommand - Child Loom GitHub PR Workflow', () => {
 		// Mock SettingsManager to return github-pr mode
 		const mockSettingsManager = {
 			loadSettings: vi.fn().mockResolvedValue({
-				mergeBehavior: { mode: 'github-pr' },
+				mergeBehavior: { mode: 'pr' },
 			}),
 		}
 

--- a/src/commands/finish.pr-workflow.test.ts
+++ b/src/commands/finish.pr-workflow.test.ts
@@ -535,7 +535,7 @@ describe('FinishCommand - Child Loom GitHub PR Workflow', () => {
 		// Mock getMergeTargetBranch to return parent branch (simulating child loom metadata)
 		vi.mocked(getMergeTargetBranch).mockResolvedValue('feat/issue-123-parent-feature')
 
-		// Mock SettingsManager to return github-pr mode
+		// Mock SettingsManager to return pr mode
 		const mockSettingsManager = {
 			loadSettings: vi.fn().mockResolvedValue({
 				mergeBehavior: { mode: 'pr' },

--- a/src/commands/finish.test.ts
+++ b/src/commands/finish.test.ts
@@ -3566,7 +3566,7 @@ describe('FinishCommand', () => {
 				})
 			})
 
-			it('should succeed with Linear provider and github-pr merge mode', async () => {
+			it('should succeed with Linear provider and pr merge mode', async () => {
 				// Mock settings with pr mode
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
@@ -3595,7 +3595,7 @@ describe('FinishCommand', () => {
 				expect(mockMergeManager.performFastForwardMerge).not.toHaveBeenCalled()
 			})
 
-			it('should succeed with Linear provider and github-draft-pr merge mode', async () => {
+			it('should succeed with Linear provider and draft-pr merge mode', async () => {
 				// Mock settings with draft-pr mode
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
@@ -3792,7 +3792,7 @@ describe('FinishCommand', () => {
 			})
 		})
 
-		describe('github-pr mode', () => {
+		describe('pr mode', () => {
 			it('should respect openBrowserOnFinish=false setting', async () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',

--- a/src/commands/finish.test.ts
+++ b/src/commands/finish.test.ts
@@ -3567,19 +3567,19 @@ describe('FinishCommand', () => {
 			})
 
 			it('should succeed with Linear provider and github-pr merge mode', async () => {
-				// Mock settings with github-pr mode
+				// Mock settings with pr mode
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
 					mergeBehavior: {
-						mode: 'github-pr',
+						mode: 'pr',
 					},
 				})
 
-				// Mock the executeGitHubPRWorkflow method to verify it's called
-				// (Issue #464: Linear + github-pr should work since PRs go through GitHub CLI)
-				const executeGitHubPRWorkflowSpy = vi
-					.spyOn(command as unknown as { executeGitHubPRWorkflow: () => Promise<void> }, 'executeGitHubPRWorkflow')
+				// Mock the executeVCSPRWorkflow method to verify it's called
+				// (Issue #464: Linear + pr mode should work since PRs go through GitHub CLI)
+				const executeVCSPRWorkflowSpy = vi
+					.spyOn(command as unknown as { executeVCSPRWorkflow: () => Promise<void> }, 'executeVCSPRWorkflow')
 					.mockResolvedValue()
 
 				await command.execute({
@@ -3589,27 +3589,27 @@ describe('FinishCommand', () => {
 
 				// Rebase runs before PR workflow
 				expect(mockMergeManager.rebaseOnMain).toHaveBeenCalled()
-				// The github-pr workflow should be executed (not the local merge)
-				expect(executeGitHubPRWorkflowSpy).toHaveBeenCalled()
+				// The pr workflow should be executed (not the local merge)
+				expect(executeVCSPRWorkflowSpy).toHaveBeenCalled()
 				// Local merge should NOT be performed (PR workflow handles merging)
 				expect(mockMergeManager.performFastForwardMerge).not.toHaveBeenCalled()
 			})
 
 			it('should succeed with Linear provider and github-draft-pr merge mode', async () => {
-				// Mock settings with github-draft-pr mode
+				// Mock settings with draft-pr mode
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 					},
 				})
 
-				// Mock the executeGitHubPRWorkflow as fallback handler
-				// When no draftPrNumber in metadata, github-draft-pr falls back to github-pr workflow
-				// (Issue #464: Linear + github-draft-pr should work since PRs go through GitHub CLI)
-				const executeGitHubPRWorkflowSpy = vi
-					.spyOn(command as unknown as { executeGitHubPRWorkflow: () => Promise<void> }, 'executeGitHubPRWorkflow')
+				// Mock the executeVCSPRWorkflow as fallback handler
+				// When no draftPrNumber in metadata, draft-pr falls back to pr workflow
+				// (Issue #464: Linear + draft-pr mode should work since PRs go through GitHub CLI)
+				const executeVCSPRWorkflowSpy = vi
+					.spyOn(command as unknown as { executeVCSPRWorkflow: () => Promise<void> }, 'executeVCSPRWorkflow')
 					.mockResolvedValue()
 
 				await command.execute({
@@ -3619,8 +3619,8 @@ describe('FinishCommand', () => {
 
 				// Rebase runs before PR workflow
 				expect(mockMergeManager.rebaseOnMain).toHaveBeenCalled()
-				// For github-draft-pr without existing draft PR, it falls back to executeGitHubPRWorkflow
-				expect(executeGitHubPRWorkflowSpy).toHaveBeenCalled()
+				// For draft-pr without existing draft PR, it falls back to executeVCSPRWorkflow
+				expect(executeVCSPRWorkflowSpy).toHaveBeenCalled()
 				// Local merge should NOT be performed (PR workflow handles merging)
 				expect(mockMergeManager.performFastForwardMerge).not.toHaveBeenCalled()
 			})
@@ -3718,7 +3718,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-draft-pr' },
+					mergeBehavior: { mode: 'draft-pr' },
 				})
 				// Spy on handlePRCleanupPrompt to avoid user prompts
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
@@ -3734,7 +3734,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-draft-pr', openBrowserOnFinish: false },
+					mergeBehavior: { mode: 'draft-pr', openBrowserOnFinish: false },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
@@ -3749,7 +3749,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-draft-pr' },
+					mergeBehavior: { mode: 'draft-pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
@@ -3764,7 +3764,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-draft-pr' },
+					mergeBehavior: { mode: 'draft-pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
@@ -3779,12 +3779,12 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-draft-pr' },
+					mergeBehavior: { mode: 'draft-pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
 
-				// JSON mode with github-draft-pr requires --cleanup or --no-cleanup
+				// JSON mode with draft-pr requires --cleanup or --no-cleanup
 				await command.execute({ identifier: '42', options: { json: true, cleanup: false } })
 
 				expect(PRManager.prototype.markPRReady).toHaveBeenCalled()
@@ -3797,7 +3797,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-pr', openBrowserOnFinish: false },
+					mergeBehavior: { mode: 'pr', openBrowserOnFinish: false },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
@@ -3814,7 +3814,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-pr' },
+					mergeBehavior: { mode: 'pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
@@ -3831,12 +3831,12 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-pr' },
+					mergeBehavior: { mode: 'pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)
 
-				// JSON mode with github-pr requires --cleanup or --no-cleanup
+				// JSON mode with pr requires --cleanup or --no-cleanup
 				await command.execute({ identifier: '42', options: { json: true, cleanup: false } })
 
 				// Verify openInBrowser (6th arg) is false in json mode
@@ -3849,7 +3849,7 @@ describe('FinishCommand', () => {
 				vi.spyOn(SettingsManager.prototype, 'loadSettings').mockResolvedValue({
 					mainBranch: 'main',
 					worktreeDir: '/test/worktrees',
-					mergeBehavior: { mode: 'github-pr' },
+					mergeBehavior: { mode: 'pr' },
 				})
 				vi.spyOn(command as never, 'handlePRCleanupPrompt' as never).mockResolvedValue(undefined as never)
 				vi.spyOn(command as never, 'generateSessionSummaryIfConfigured' as never).mockResolvedValue(undefined as never)

--- a/src/commands/finish.ts
+++ b/src/commands/finish.ts
@@ -928,23 +928,6 @@ export class FinishCommand {
 			return
 		}
 
-		if (mergeBehavior.mode === 'bitbucket-pr') {
-			// For BitBucket, we use the VCS provider layer - NOT the issue tracker
-			// This allows Jira/Linear issues to create PRs in BitBucket
-			const { VCSProviderFactory } = await import('../lib/VCSProviderFactory.js')
-			const vcsProvider = VCSProviderFactory.create(settings)
-
-			if (!vcsProvider || vcsProvider.providerName !== 'bitbucket') {
-				throw new Error(
-					`The 'bitbucket-pr' merge mode requires BitBucket VCS configuration. ` +
-					`Add versionControl.provider: 'bitbucket' to your settings.`
-				)
-			}
-
-			await this.executeBitBucketPRWorkflow(parsed, options, worktree, settings, vcsProvider, result)
-			return
-		}
-
 		// Step 6: Perform fast-forward merge
 		getLogger().info('Performing fast-forward merge...')
 		await this.mergeManager.performFastForwardMerge(worktree.branch, worktree.path, mergeOptions)
@@ -1163,10 +1146,6 @@ export class FinishCommand {
 		// Step 5: Create or open PR — route to VCS provider or legacy PRManager
 		if (vcsProvider !== null) {
 			// VCS provider path (e.g., BitBucket from PR #609)
-			const openInBrowser = !options.noBrowser
-				&& !options.json
-				&& settings.mergeBehavior?.openBrowserOnFinish !== false
-
 			if (options.dryRun) {
 				getLogger().info(`[DRY RUN] Would create ${vcsProvider.providerName} PR`)
 				getLogger().info(`  Title: ${prTitle}`)
@@ -1179,27 +1158,55 @@ export class FinishCommand {
 				return
 			}
 
-			const createPROptions: Parameters<typeof vcsProvider.createPR>[0] = {
-				branch: worktree.branch,
-				title: prTitle,
-				baseBranch,
-				worktreePath: worktree.path,
-				openInBrowser,
-			}
-			if (parsed.type === 'issue' && parsed.number) {
-				createPROptions.issueNumber = parsed.number
-			}
-			const prResult = await vcsProvider.createPR(createPROptions)
+			// Check for existing PR first
+			const existingPR = await vcsProvider.checkForExistingPR(worktree.branch, worktree.path)
 
-			getLogger().success(`Pull request created: ${prResult.url}`)
-			finishResult.operations.push({
-				type: 'pr-creation',
-				message: prResult.wasExisting ? 'Found existing pull request' : 'Pull request created',
-				success: true,
-			})
-			finishResult.prUrl = prResult.url
+			if (existingPR) {
+				getLogger().success(`Existing pull request: ${existingPR.url}`)
+				finishResult.prUrl = existingPR.url
+				finishResult.operations.push({
+					type: 'pr-creation',
+					message: 'Found existing pull request',
+					success: true,
+				})
 
-			await this.generateSessionSummaryIfConfigured(parsed, worktree, options, prResult.number)
+				await this.generateSessionSummaryIfConfigured(parsed, worktree, options, existingPR.number)
+			} else {
+				// Generate PR body
+				const prBody = await prManager.generatePRBody(
+					parsed.type === 'issue' ? parsed.number : undefined,
+					worktree.path
+				)
+
+				const prUrl = await vcsProvider.createPR(
+					worktree.branch,
+					prTitle,
+					prBody,
+					baseBranch,
+					worktree.path
+				)
+
+				getLogger().success(`Pull request created: ${prUrl}`)
+				finishResult.prUrl = prUrl
+				finishResult.operations.push({
+					type: 'pr-creation',
+					message: 'Pull request created',
+					success: true,
+				})
+			}
+
+			// Open in browser if configured
+			const shouldOpenBrowser = !options.noBrowser
+				&& !options.json
+				&& settings.mergeBehavior?.openBrowserOnFinish !== false
+			if (shouldOpenBrowser && finishResult.prUrl) {
+				try {
+					const { openBrowser } = await import('../utils/browser.js')
+					await openBrowser(finishResult.prUrl)
+				} catch {
+					getLogger().debug('Could not open browser')
+				}
+			}
 
 			const metadataManager = new MetadataManager()
 			await metadataManager.archiveMetadata(worktree.path)
@@ -1277,129 +1284,6 @@ export class FinishCommand {
 			}
 
 			// Step 5: Interactive cleanup prompt (unless flags override)
-			await this.handlePRCleanupPrompt(parsed, options, worktree, finishResult)
-		}
-	}
-
-	/**
-	 * Execute workflow for BitBucket PR creation (bitbucket-pr merge mode)
-	 * Validates -> Commits -> Pushes -> Creates PR -> Prompts for cleanup
-	 *
-	 * Unlike GitHub PR workflow, this uses the VersionControlProvider abstraction
-	 * instead of PRManager, allowing it to work with any issue tracker (Jira, Linear, etc.)
-	 */
-	private async executeBitBucketPRWorkflow(
-		parsed: ParsedFinishInput,
-		options: FinishOptions,
-		worktree: GitWorktree,
-		settings: import('../lib/SettingsManager.js').IloomSettings,
-		vcsProvider: import('../lib/VersionControlProvider.js').VersionControlProvider,
-		finishResult: FinishResult
-	): Promise<void> {
-		// Step 1: Push branch to origin
-		if (options.dryRun) {
-			getLogger().info('[DRY RUN] Would push branch to origin')
-		} else {
-			getLogger().info('Pushing branch to origin...')
-			await pushBranchToRemote(worktree.branch, worktree.path, { dryRun: false })
-			getLogger().success('Branch pushed successfully')
-		}
-
-		// Step 2: Generate PR title from issue if available
-		// Note: parsed.number already has correct case from parseInput() metadata lookup
-		let prTitle = `Work from ${worktree.branch}`
-		if (parsed.type === 'issue' && parsed.number) {
-			try {
-				const issue = await this.issueTracker.fetchIssue(parsed.number)
-
-				// Apply ticket prefix if enabled (default: false)
-				if (settings.mergeBehavior?.prTitlePrefix) {
-					prTitle = `${parsed.number}: ${issue.title}`
-				} else {
-					prTitle = issue.title
-				}
-			} catch (error) {
-				getLogger().debug('Could not fetch issue title, using branch name', { error })
-			}
-		}
-
-		// Step 3: Get base branch (respects parent loom metadata for child looms)
-		const baseBranch = await getMergeTargetBranch(worktree.path)
-
-		// Step 4: Check for existing PR or create new one
-		if (options.dryRun) {
-			getLogger().info('[DRY RUN] Would create BitBucket PR')
-			getLogger().info(`  Title: ${prTitle}`)
-			getLogger().info(`  Base: ${baseBranch}`)
-			finishResult.operations.push({
-				type: 'pr-creation',
-				message: 'Would create BitBucket PR (dry-run)',
-				success: true,
-			})
-		} else {
-			// Check for existing PR first
-			const existingPR = await vcsProvider.checkForExistingPR(worktree.branch, worktree.path)
-
-			if (existingPR) {
-				getLogger().success(`Existing pull request: ${existingPR.url}`)
-				finishResult.prUrl = existingPR.url
-				finishResult.operations.push({
-					type: 'pr-creation',
-					message: 'Found existing pull request',
-					success: true,
-				})
-			} else {
-				// Generate PR body using Claude (same as GitHub workflow)
-				const { PRManager } = await import('../lib/PRManager.js')
-				const prManager = new PRManager(settings)
-				const prBody = await prManager.generatePRBody(
-					parsed.type === 'issue' ? parsed.number : undefined,
-					worktree.path
-				)
-
-				// Create new PR
-				const prUrl = await vcsProvider.createPR(
-					worktree.branch,
-					prTitle,
-					prBody,
-					baseBranch,
-					worktree.path
-				)
-				getLogger().success(`Pull request created: ${prUrl}`)
-				finishResult.prUrl = prUrl
-				finishResult.operations.push({
-					type: 'pr-creation',
-					message: 'Pull request created',
-					success: true,
-				})
-
-				// Move issue to Ready for Review state
-				if (parsed.type === 'issue' && parsed.number) {
-					try {
-						if (this.issueTracker.moveIssueToReadyForReview) {
-							await this.issueTracker.moveIssueToReadyForReview(parsed.number)
-							getLogger().info('Issue moved to Ready for Review')
-						}
-					} catch (error) {
-						getLogger().warn(
-							`Failed to move issue to Ready for Review: ${error instanceof Error ? error.message : 'Unknown error'}`,
-							error
-						)
-					}
-				}
-			}
-
-			// Generate session summary - posts to the ISSUE (Jira/Linear), not the PR
-			// For BitBucket workflows, the issue tracker (Jira/Linear) doesn't support PR comments,
-			// so we post to the issue where the knowledge capture belongs
-			await this.generateSessionSummaryIfConfigured(parsed, worktree, options)
-
-			// Archive metadata BEFORE cleanup prompt (ensures it runs even with --no-cleanup)
-			const { MetadataManager } = await import('../lib/MetadataManager.js')
-			const metadataManager = new MetadataManager()
-			await metadataManager.archiveMetadata(worktree.path)
-
-			// Interactive cleanup prompt (unless flags override)
 			await this.handlePRCleanupPrompt(parsed, options, worktree, finishResult)
 		}
 	}

--- a/src/commands/ignite.test.ts
+++ b/src/commands/ignite.test.ts
@@ -2756,7 +2756,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						// autoCommitPush not set - should default to true
 					},
 				}),
@@ -2820,7 +2820,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						autoCommitPush: false, // Explicitly disabled
 					},
 				}),
@@ -2945,7 +2945,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						remote: 'my_remote-123',
 					},
 				}),
@@ -3006,7 +3006,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						remote: 'origin; rm -rf /',
 					},
 				}),
@@ -3064,7 +3064,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						remote: 'my remote',
 					},
 				}),
@@ -3122,7 +3122,7 @@ describe('IgniteCommand', () => {
 			const mockSettingsManager = {
 				loadSettings: vi.fn().mockResolvedValue({
 					mergeBehavior: {
-						mode: 'github-draft-pr',
+						mode: 'draft-pr',
 						// remote not set - should default to 'origin'
 					},
 				}),

--- a/src/commands/ignite.ts
+++ b/src/commands/ignite.ts
@@ -391,7 +391,7 @@ export class IgniteCommand {
 			if (context.type === 'issue' || context.type === 'pr') {
 				try {
 					const provider = this.settings ? IssueTrackerFactory.getProviderName(this.settings) : 'github'
-					// Pass draftPrNumber to route comments to PR when in github-draft-pr mode
+					// Pass draftPrNumber to route comments to PR when in draft-pr mode
 					mcpConfig = await generateIssueManagementMcpConfig(context.type, undefined, provider, this.settings, draftPrNumber)
 					logger.debug('Generated MCP configuration for issue management', { provider, draftPrNumber })
 
@@ -633,7 +633,7 @@ export class IgniteCommand {
 		}
 
 		// Set draft PR mode flags (mutually exclusive)
-		// When draftPrNumber is set, we're in github-draft-pr mode
+		// When draftPrNumber is set, we're in draft-pr mode
 		if (draftPrNumber !== undefined) {
 			variables.DRAFT_PR_MODE = true
 			variables.DRAFT_PR_NUMBER = draftPrNumber

--- a/src/commands/summary.test.ts
+++ b/src/commands/summary.test.ts
@@ -561,13 +561,13 @@ describe('SummaryCommand', () => {
 	})
 
 	describe('postSummary PR routing', () => {
-		it('should post to PR when mergeMode is github-draft-pr and draftPrNumber exists', async () => {
+		it('should post to PR when mergeMode is draft-pr and draftPrNumber exists', async () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-			// Configure github-draft-pr mode with draftPrNumber in metadata
+			// Configure draft-pr mode with draftPrNumber in metadata
 			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({
 				...defaultSettings,
-				mergeBehavior: { mode: 'github-draft-pr' },
+				mergeBehavior: { mode: 'draft-pr' },
 			})
 			vi.mocked(mockMetadataManager.readMetadata).mockResolvedValue({
 				...defaultMetadata,
@@ -592,13 +592,13 @@ describe('SummaryCommand', () => {
 			consoleSpy.mockRestore()
 		})
 
-		it('should post to PR when mergeMode is github-pr and PR exists for branch', async () => {
+		it('should post to PR when mergeMode is pr and PR exists for branch', async () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-			// Configure github-pr mode
+			// Configure pr mode
 			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({
 				...defaultSettings,
-				mergeBehavior: { mode: 'github-pr' },
+				mergeBehavior: { mode: 'pr' },
 			})
 
 			// Mock PRManager to return an existing PR
@@ -625,13 +625,13 @@ describe('SummaryCommand', () => {
 			consoleSpy.mockRestore()
 		})
 
-		it('should fall back to issue when github-pr mode but no PR found', async () => {
+		it('should fall back to issue when pr mode but no PR found', async () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-			// Configure github-pr mode
+			// Configure pr mode
 			vi.mocked(mockSettingsManager.loadSettings).mockResolvedValue({
 				...defaultSettings,
-				mergeBehavior: { mode: 'github-pr' },
+				mergeBehavior: { mode: 'pr' },
 			})
 
 			// Mock PRManager to return no existing PR

--- a/src/commands/summary.ts
+++ b/src/commands/summary.ts
@@ -61,12 +61,12 @@ export class SummaryCommand {
 		const settings = await this.settingsManager.loadSettings(worktreePath)
 		const mergeMode = settings.mergeBehavior?.mode ?? 'local'
 
-		if (mergeMode === 'github-draft-pr') {
+		if ((mergeMode as string) === 'draft-pr') {
 			const metadata = await this.metadataManager.readMetadata(worktreePath)
 			return metadata?.draftPrNumber ?? undefined
 		}
 
-		if (mergeMode === 'github-pr') {
+		if ((mergeMode as string) === 'pr') {
 			const prManager = new PRManager(settings)
 			const existingPR = await prManager.checkForExistingPR(branchName, worktreePath)
 			return existingPR?.number

--- a/src/lib/MergeManager.test.ts
+++ b/src/lib/MergeManager.test.ts
@@ -486,7 +486,7 @@ describe('MergeManager', () => {
 		})
 
 		it('should use local parent branch for child looms (any mode, no fetch)', async () => {
-			// Setup: github-pr mode BUT child loom (has parent)
+			// Setup: pr mode BUT child loom (has parent)
 			mockMetadataManager.readMetadata = vi.fn().mockResolvedValue({
 				parentLoom: { branchName: 'fix/parent-branch', identifier: 'issue-100' }
 			})

--- a/src/lib/MergeManager.test.ts
+++ b/src/lib/MergeManager.test.ts
@@ -46,9 +46,9 @@ describe('MergeManager', () => {
 		// Default: no rebase in progress (fs.access rejects = directory doesn't exist)
 		mockFsAccess.mockRejectedValue(new Error('ENOENT'))
 
-		// Create a mock SettingsManager - default to github-pr mode (uses origin/)
+		// Create a mock SettingsManager - default to pr mode (uses origin/)
 		mockSettingsManager = {
-			loadSettings: vi.fn().mockResolvedValue({ mergeBehavior: { mode: 'github-pr' } }),
+			loadSettings: vi.fn().mockResolvedValue({ mergeBehavior: { mode: 'pr' } }),
 		} as unknown as SettingsManager
 
 		// Create a mock MetadataManager - default to non-child loom
@@ -397,8 +397,8 @@ describe('MergeManager', () => {
 	})
 
 	describe('Conditional Origin/Local Branch Target', () => {
-		it('should use origin/{mainBranch} in github-pr mode (non-child)', async () => {
-			// Setup: github-pr mode (already default), non-child loom
+		it('should use origin/{mainBranch} in pr mode (non-child)', async () => {
+			// Setup: pr mode (already default), non-child loom
 			// Mock: successful rebase on origin/main
 			vi.mocked(git.executeGitCommand)
 				.mockResolvedValueOnce('/test/worktree/.git') // rev-parse --absolute-git-dir (isRebaseInProgress)
@@ -427,9 +427,9 @@ describe('MergeManager', () => {
 			)
 		})
 
-		it('should use origin/{mainBranch} in github-draft-pr mode (non-child)', async () => {
-			// Setup: github-draft-pr mode
-			mockSettingsManager.loadSettings = vi.fn().mockResolvedValue({ mergeBehavior: { mode: 'github-draft-pr' } })
+		it('should use origin/{mainBranch} in draft-pr mode (non-child)', async () => {
+			// Setup: draft-pr mode
+			mockSettingsManager.loadSettings = vi.fn().mockResolvedValue({ mergeBehavior: { mode: 'draft-pr' } })
 
 			// Mock: successful rebase on origin/main
 			vi.mocked(git.executeGitCommand)

--- a/src/lib/MergeManager.ts
+++ b/src/lib/MergeManager.ts
@@ -52,13 +52,13 @@ export class MergeManager {
 
 		// Determine whether to use remote (origin/) or local branch reference
 		// - Child looms: always use local parent branch (parent may not be pushed)
-		// - PR modes (github-pr, github-draft-pr) for non-child: fetch and use origin/{branch}
+		// - PR modes (pr, draft-pr) for non-child: fetch and use origin/{branch}
 		// - Local mode: use local branch (no fetch)
 		const metadata = await this.metadataManager.readMetadata(worktreePath)
 		const isChildLoom = !!metadata?.parentLoom
 		const settings = await this.settingsManager.loadSettings(worktreePath)
 		const mergeBehaviorMode = settings.mergeBehavior?.mode ?? 'local'
-		const isPRMode = mergeBehaviorMode === 'github-pr' || mergeBehaviorMode === 'github-draft-pr'
+		const isPRMode = mergeBehaviorMode === 'pr' || mergeBehaviorMode === 'draft-pr'
 		const useRemote = isPRMode && !isChildLoom
 
 		let targetBranch: string

--- a/src/lib/MetadataManager.ts
+++ b/src/lib/MetadataManager.ts
@@ -28,7 +28,7 @@ export interface MetadataFile {
   projectPath?: string // Main worktree path (project root) - enables project identification
   issueUrls?: Record<string, string> // Map of issue ID to URL in the issue tracker
   prUrls?: Record<string, string> // Map of PR number to URL in the issue tracker
-  draftPrNumber?: number // Draft PR number if github-draft-pr mode was used
+  draftPrNumber?: number // Draft PR number if draft-pr mode was used
   oneShot?: OneShotMode // One-shot automation mode stored during loom creation
   complexity?: ComplexityOverride // Complexity override stored during loom creation
   capabilities?: ProjectCapability[] // Detected project capabilities
@@ -71,7 +71,7 @@ export interface WriteMetadataInput {
   projectPath: string // Main worktree path (project root) - required for new looms
   issueUrls: Record<string, string> // Map of issue ID to URL in the issue tracker
   prUrls: Record<string, string> // Map of PR number to URL in the issue tracker
-  draftPrNumber?: number // Draft PR number for github-draft-pr mode
+  draftPrNumber?: number // Draft PR number for draft-pr mode
   oneShot?: OneShotMode // One-shot automation mode to persist
   complexity?: ComplexityOverride // Complexity override to persist
   capabilities: ProjectCapability[] // Detected project capabilities (required for new looms)

--- a/src/lib/PRManager.test.ts
+++ b/src/lib/PRManager.test.ts
@@ -18,7 +18,7 @@ describe('PRManager', () => {
 	beforeEach(() => {
 		mockSettings = {
 			mergeBehavior: {
-				mode: 'github-pr',
+				mode: 'pr',
 			},
 			issueManagement: {
 				github: {
@@ -200,7 +200,7 @@ describe('PRManager', () => {
 		})
 
 		it('should target correct remote based on settings and use owner:branch format', async () => {
-			mockSettings.mergeBehavior = { mode: 'github-pr', remote: 'upstream' }
+			mockSettings.mergeBehavior = { mode: 'pr', remote: 'upstream' }
 			prManager = new PRManager(mockSettings)
 
 			vi.mocked(remoteUtils.getEffectivePRTargetRemote).mockResolvedValueOnce('upstream')
@@ -428,7 +428,7 @@ describe('PRManager', () => {
 		})
 
 		it('should prefer mergeBehavior.remote over issueManagement.github.remote', async () => {
-			mockSettings.mergeBehavior = { mode: 'github-pr', remote: 'upstream-custom' }
+			mockSettings.mergeBehavior = { mode: 'pr', remote: 'upstream-custom' }
 			mockSettings.issueManagement = {
 				github: {
 					remote: 'upstream-default',

--- a/src/lib/PRManager.ts
+++ b/src/lib/PRManager.ts
@@ -366,7 +366,7 @@ Start your response immediately with the PR body text.
 
 	/**
 	 * Create a draft PR for the branch
-	 * Used by github-draft-pr mode during il start
+	 * Used by draft-pr mode during il start
 	 * @param branchName - Branch to create PR from (used as --head)
 	 * @param title - PR title
 	 * @param body - PR body
@@ -443,7 +443,7 @@ Start your response immediately with the PR body text.
 
 	/**
 	 * Mark a draft PR as ready for review
-	 * Used by github-draft-pr mode during il finish
+	 * Used by draft-pr mode during il finish
 	 * @param prNumber - PR number to mark ready
 	 * @param cwd - Working directory
 	 */

--- a/src/lib/PromptTemplateManager.ts
+++ b/src/lib/PromptTemplateManager.ts
@@ -48,7 +48,7 @@ export interface TemplateVariables {
 	// Draft PR mode variables - mutually exclusive with standard issue mode
 	DRAFT_PR_NUMBER?: number  // PR number for draft PR workflow
 	DRAFT_PR_URL?: string     // Full URL of the draft PR (e.g., https://github.com/owner/repo/pull/123)
-	DRAFT_PR_MODE?: boolean   // True when using github-draft-pr merge mode
+	DRAFT_PR_MODE?: boolean   // True when using draft-pr merge mode
 	AUTO_COMMIT_PUSH?: boolean  // True when auto-commit/push is enabled for draft PR mode
 	STANDARD_ISSUE_MODE?: boolean  // True when using standard issue commenting (not draft PR)
 	STANDARD_BRANCH_MODE?: boolean // True when using standard branch mode (not draft PR)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,7 +188,7 @@ export interface FinishOptions {
   dryRun?: boolean    // -n, --dry-run - Preview actions without executing
   pr?: number         // --pr <number> - Treat input as PR number
   skipBuild?: boolean // --skip-build - Skip post-merge build verification
-  noBrowser?: boolean // --no-browser - Skip opening PR in browser (github-pr mode only)
+  noBrowser?: boolean // --no-browser - Skip opening PR in browser (pr mode only)
   cleanup?: boolean   // --cleanup / --no-cleanup - Control worktree cleanup after finishing
   json?: boolean      // --json - Output result as JSON
   skipToPr?: boolean  // --skip-to-pr - Skip rebase/validation/commit, go directly to PR creation (debug)

--- a/src/types/telemetry.ts
+++ b/src/types/telemetry.ts
@@ -32,7 +32,7 @@ export interface LoomCreatedProperties {
 }
 
 export interface LoomFinishedProperties {
-  merge_behavior: 'local' | 'github-pr' | 'github-draft-pr'
+  merge_behavior: 'local' | 'pr' | 'draft-pr'
   duration_minutes: number
 }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1100,7 +1100,7 @@ export async function getMergeTargetBranch(
 }
 
 /**
- * Placeholder commit prefix used by github-draft-pr mode.
+ * Placeholder commit prefix used by draft-pr mode.
  * Created during il start to enable draft PR creation (GitHub requires at least one commit ahead of base).
  * Removed during il finish before the final push to maintain clean commit history.
  */

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -14,7 +14,7 @@ import type { LoomMetadata } from '../lib/MetadataManager.js'
  * @param repo - Optional repo in "owner/repo" format. If not provided, will auto-detect from git.
  * @param provider - Issue management provider (default: 'github')
  * @param settings - Optional settings to extract Linear API token from
- * @param draftPrNumber - Optional draft PR number for github-draft-pr mode (routes comments to PR)
+ * @param draftPrNumber - Optional draft PR number for draft-pr mode (routes comments to PR)
  */
 export async function generateIssueManagementMcpConfig(
 	contextType?: 'issue' | 'pr',
@@ -23,7 +23,7 @@ export async function generateIssueManagementMcpConfig(
 	settings?: IloomSettings,
 	draftPrNumber?: number
 ): Promise<Record<string, unknown>[]> {
-	// When draftPrNumber is provided (github-draft-pr mode), force contextType to 'pr'
+	// When draftPrNumber is provided (draft-pr mode), force contextType to 'pr'
 	// This ensures agents route comments to the draft PR instead of the issue
 	const effectiveContextType = draftPrNumber ? 'pr' : contextType
 

--- a/templates/prompts/init-prompt.txt
+++ b/templates/prompts/init-prompt.txt
@@ -389,11 +389,11 @@ Since this repository has multiple git remotes, GitHub Issues is suggested as th
 
 **Note on Provider + Merge Mode Combinations:**
 - GitHub Issues + local merge: Requires authorized GitHub CLI (`gh`)
-- GitHub Issues + github-pr or github-draft-pr: Requires authorized GitHub CLI (`gh`)
+- GitHub Issues + pr or draft-pr: Requires authorized GitHub CLI (`gh`)
 - Linear Issues + local merge: Requires Linear API token only
-- Linear Issues + github-pr or github-draft-pr: Requires BOTH Linear API token AND authorized GitHub CLI (`gh`)
+- Linear Issues + pr or draft-pr: Requires BOTH Linear API token AND authorized GitHub CLI (`gh`)
 - Jira Cloud + local merge: Requires Jira credentials (host, username, API token) only
-- Jira Cloud + github-pr or github-draft-pr: Requires BOTH Jira credentials AND authorized GitHub CLI (`gh`)
+- Jira Cloud + pr or draft-pr: Requires BOTH Jira credentials AND authorized GitHub CLI (`gh`)
 
 **Step 2: Provider-Specific Configuration**
 
@@ -525,17 +525,18 @@ This repository has multiple git remotes detected. iloom needs to know which rem
    - Question format: "How should iloom handle finishing work?{{#if currentMergeMode}} (Currently: [currentMergeMode]){{/if}}"
    - Options:
      - "local" - Merge changes locally (traditional workflow)
-     - "github-pr" - Create GitHub PR when finishing (for PR-based workflows)
-     - "github-draft-pr" - Create draft PR at start, mark ready when finishing (recommended for forks)
+     - "pr" - Create a PR when finishing (for PR-based workflows)
+     - "draft-pr" - Create draft PR at start, mark ready when finishing (recommended for forks)
    - Default:
-     - If origin + upstream remotes detected (fork pattern): "github-draft-pr"
+     - If origin + upstream remotes detected (fork pattern): "draft-pr"
      - Otherwise: currentMergeMode or "local"
-   - Validation: Must be one of: local, github-pr, github-draft-pr
+   - Validation: Must be one of: local, pr, draft-pr
    - Store answer as: `mergeBehavior.mode`
    - Context:
-     - **Fork workflows (with upstream remote)**: Use "github-draft-pr" mode. This creates a draft PR at the start of work, routes all AI agent comments to the PR (not the issue), and marks the PR ready for review when you finish. This keeps upstream issue trackers clean.
-     - **Direct contribution workflows**: Use "github-pr" to create PRs when finishing, or "local" to merge locally.
-   - **IMPORTANT**: Both "github-pr" and "github-draft-pr" modes require GitHub CLI (`gh`) to be installed and authenticated, regardless of your issue tracker provider.
+     - **Fork workflows (with upstream remote)**: Use "draft-pr" mode. This creates a draft PR at the start of work, routes all AI agent comments to the PR (not the issue), and marks the PR ready for review when you finish. This keeps upstream issue trackers clean.
+     - **Direct contribution workflows**: Use "pr" to create PRs when finishing, or "local" to merge locally.
+     - **Provider note**: The VCS provider (currently GitHub) determines how PRs are created. The mode value is provider-agnostic.
+   - **IMPORTANT**: Both "pr" and "draft-pr" modes require GitHub CLI (`gh`) to be installed and authenticated, regardless of your issue tracker provider.
 
 **Implementation Details:**
 - Ask Step 1 first to determine provider
@@ -781,11 +782,11 @@ When both settings.json and settings.local.json exist, you MUST prevent duplicat
    ```json
    {
      "mergeBehavior": {
-       "mode": "<user's answer>"  // "github-pr" or "github-draft-pr"
+       "mode": "<user's answer>"  // "pr" or "draft-pr"
      }
    }
    ```
-   Note: Valid modes are "local", "github-pr", and "github-draft-pr". Only include if not "local".
+   Note: Valid modes are "local", "pr", and "draft-pr". Only include if not "local".
 
 7. **Combine all applicable sections** into a single JSON object. Only include sections where the value differs from the default.
 


### PR DESCRIPTION
Fixes #842

## Summary

Replaces provider-specific merge mode values (`github-pr`, `github-draft-pr`, `bitbucket-pr`) with generic ones (`local`, `pr`, `draft-pr`). The VCS provider determines how PRs are created, not the mode name.

- Backwards-compatible Zod transform maps old values at parse time
- Finish command routes PR creation via VCSProviderFactory
- Draft PR fallback when provider doesn't support drafts
- All docs, init wizard, and CLI updated

## Commits

- #850: Schema and types with backwards-compatible transform
- #853: Summary, contribute, and CLI commands
- #851: Finish command PR workflow unification
- #854: Init wizard and documentation
- #852: LoomManager and MergeManager
- #855: Integration verification and stale reference cleanup